### PR TITLE
Fix the missing CFBundleSupportedPlatforms property.

### DIFF
--- a/BusyNavigationBar/BusyNavigationBar/Info.plist
+++ b/BusyNavigationBar/BusyNavigationBar/Info.plist
@@ -18,6 +18,10 @@
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
The missing `CFBundleSupportedPlatforms` property causes an issue when submitting to the App Store.